### PR TITLE
Fix/OB-53_AddNormalize

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,6 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
 
 
 @layer base {


### PR DESCRIPTION
It seems the preflight has already been installed.
Before any manipulations, I've tried to disable it 
<img width="408" alt="Screenshot 2023-09-26 at 16 03 10" src="https://github.com/Alex-2kZharkov/oldboy-barbershop/assets/119830208/392656d9-bb40-4a45-bec7-aee67afc563b">
This caused a mess
<img width="1440" alt="Screenshot 2023-09-26 at 16 02 50" src="https://github.com/Alex-2kZharkov/oldboy-barbershop/assets/119830208/fb129a9f-aaaf-4668-a6b4-43a3489bdc1a">
So I've just edited imports syntax
<img width="611" alt="Screenshot 2023-09-26 at 16 02 33" src="https://github.com/Alex-2kZharkov/oldboy-barbershop/assets/119830208/f85d68e0-79b4-4c82-8049-e59b7ae8fa3c">
